### PR TITLE
Use a Pkg struct instead of string in dependencies

### DIFF
--- a/src/dependency_provider.rs
+++ b/src/dependency_provider.rs
@@ -51,7 +51,8 @@ use std::error::Error;
 use std::path::PathBuf;
 use std::str::FromStr;
 
-use crate::pkg_version::{Cache, Pkg, PkgVersion};
+use crate::pkg_version::{Cache, PkgVersion};
+use crate::project_config::Pkg;
 
 /// Dependency provider of a package or an application elm project.
 /// Will only work properly if used to resolve dependencies for its root.

--- a/src/pkg_version.rs
+++ b/src/pkg_version.rs
@@ -2,12 +2,11 @@ use pubgrub::version::{SemanticVersion as SemVer, VersionParseError};
 use serde::{Deserialize, Serialize};
 use serde_json;
 use std::collections::{BTreeMap, BTreeSet};
-use std::fmt;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use thiserror::Error;
 
-use crate::project_config::PackageConfig;
+use crate::project_config::{PackageConfig, Pkg, PkgParseError};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(transparent)]
@@ -19,12 +18,6 @@ pub struct Cache {
 pub struct PkgVersion {
     pub author_pkg: Pkg,
     pub version: SemVer,
-}
-
-#[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq, Serialize, Deserialize)]
-pub struct Pkg {
-    pub author: String,
-    pub pkg: String,
 }
 
 #[derive(Error, Debug)]
@@ -67,12 +60,6 @@ pub enum PkgVersionParseError {
     VersionParseError(#[from] VersionParseError),
     #[error("failed to parse the package")]
     PkgParseError(#[from] PkgParseError),
-}
-
-#[derive(Error, Debug)]
-pub enum PkgParseError {
-    #[error("no author/package separation found in `{0}`")]
-    NoAuthorSeparator(String),
 }
 
 impl Cache {
@@ -276,37 +263,6 @@ impl PkgVersion {
     }
 }
 
-// Public Pkg methods.
-impl Pkg {
-    pub fn config_path<P: AsRef<Path>>(&self, elm_home: P, elm_version: &str) -> PathBuf {
-        Self::packages_dir(elm_home, elm_version)
-            .join(&self.author)
-            .join(&self.pkg)
-    }
-}
-
-// Private Pkg methods.
-impl Pkg {
-    fn to_url(&self, remote_base_url: &str) -> String {
-        format!("{}/packages/{}/{}", remote_base_url, self.author, self.pkg)
-    }
-
-    fn pubgrub_cache_dir_json<P: AsRef<Path>>(&self, elm_home: P) -> PathBuf {
-        Self::pubgrub_cache_dir(elm_home)
-            .join("elm_json_cache")
-            .join(&self.author)
-            .join(&self.pkg)
-    }
-
-    fn pubgrub_cache_dir<P: AsRef<Path>>(elm_home: P) -> PathBuf {
-        elm_home.as_ref().join("pubgrub")
-    }
-
-    fn packages_dir<P: AsRef<Path>>(elm_home: P, elm_version: &str) -> PathBuf {
-        elm_home.as_ref().join(elm_version).join("packages")
-    }
-}
-
 impl FromStr for PkgVersion {
     type Err = PkgVersionParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -319,23 +275,5 @@ impl FromStr for PkgVersion {
             author_pkg,
             version,
         })
-    }
-}
-
-impl FromStr for Pkg {
-    type Err = PkgParseError;
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let author_sep = s
-            .find('/')
-            .ok_or_else(|| PkgParseError::NoAuthorSeparator(s.to_string()))?;
-        let author = s[0..author_sep].to_string();
-        let pkg = s[(author_sep + 1)..].to_string();
-        Ok(Pkg { author, pkg })
-    }
-}
-
-impl fmt::Display for Pkg {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}/{}", &self.author, &self.pkg)
     }
 }

--- a/src/project_config.rs
+++ b/src/project_config.rs
@@ -5,6 +5,10 @@ use pubgrub::range::Range;
 use pubgrub::version::SemanticVersion as SemVer;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap as Map;
+use std::fmt;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use thiserror::Error;
 
 /// Project configuration in an elm.json.
 /// It either is a package or an application.
@@ -46,6 +50,18 @@ pub struct PackageConfig {
     pub test_dependencies: Map<String, Constraint>,
 }
 
+#[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq, Serialize, Deserialize)]
+pub struct Pkg {
+    pub author: String,
+    pub pkg: String,
+}
+
+#[derive(Error, Debug)]
+pub enum PkgParseError {
+    #[error("no author/package separation found in `{0}`")]
+    NoAuthorSeparator(String),
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum ExposedModules {
@@ -58,5 +74,54 @@ impl PackageConfig {
         self.dependencies
             .iter()
             .map(|(p, constraint)| (p, &constraint.0))
+    }
+}
+
+// Public Pkg methods.
+impl Pkg {
+    pub fn config_path<P: AsRef<Path>>(&self, elm_home: P, elm_version: &str) -> PathBuf {
+        Self::packages_dir(elm_home, elm_version)
+            .join(&self.author)
+            .join(&self.pkg)
+    }
+
+    pub fn pubgrub_cache_dir<P: AsRef<Path>>(elm_home: P) -> PathBuf {
+        elm_home.as_ref().join("pubgrub")
+    }
+
+    pub fn to_url(&self, remote_base_url: &str) -> String {
+        format!("{}/packages/{}/{}", remote_base_url, self.author, self.pkg)
+    }
+
+    pub fn pubgrub_cache_dir_json<P: AsRef<Path>>(&self, elm_home: P) -> PathBuf {
+        Self::pubgrub_cache_dir(elm_home)
+            .join("elm_json_cache")
+            .join(&self.author)
+            .join(&self.pkg)
+    }
+}
+
+// Private Pkg methods.
+impl Pkg {
+    fn packages_dir<P: AsRef<Path>>(elm_home: P, elm_version: &str) -> PathBuf {
+        elm_home.as_ref().join(elm_version).join("packages")
+    }
+}
+
+impl FromStr for Pkg {
+    type Err = PkgParseError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let author_sep = s
+            .find('/')
+            .ok_or_else(|| PkgParseError::NoAuthorSeparator(s.to_string()))?;
+        let author = s[0..author_sep].to_string();
+        let pkg = s[(author_sep + 1)..].to_string();
+        Ok(Pkg { author, pkg })
+    }
+}
+
+impl fmt::Display for Pkg {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}/{}", &self.author, &self.pkg)
     }
 }

--- a/src/project_config.rs
+++ b/src/project_config.rs
@@ -32,8 +32,8 @@ pub struct ApplicationConfig {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AppDependencies {
-    pub direct: Map<String, SemVer>,
-    pub indirect: Map<String, SemVer>,
+    pub direct: Map<Pkg, SemVer>,
+    pub indirect: Map<Pkg, SemVer>,
 }
 
 /// Struct representing a package elm.json.
@@ -46,11 +46,11 @@ pub struct PackageConfig {
     pub version: SemVer,
     pub elm_version: Constraint,
     pub exposed_modules: ExposedModules,
-    pub dependencies: Map<String, Constraint>,
-    pub test_dependencies: Map<String, Constraint>,
+    pub dependencies: Map<Pkg, Constraint>,
+    pub test_dependencies: Map<Pkg, Constraint>,
 }
 
-#[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct Pkg {
     pub author: String,
     pub pkg: String,
@@ -70,7 +70,7 @@ pub enum ExposedModules {
 }
 
 impl PackageConfig {
-    pub fn dependencies_iter(&self) -> impl Iterator<Item = (&String, &Range<SemVer>)> {
+    pub fn dependencies_iter(&self) -> impl Iterator<Item = (&Pkg, &Range<SemVer>)> {
         self.dependencies
             .iter()
             .map(|(p, constraint)| (p, &constraint.0))
@@ -79,6 +79,10 @@ impl PackageConfig {
 
 // Public Pkg methods.
 impl Pkg {
+    pub fn new(author: String, pkg: String) -> Self {
+        Self { author, pkg }
+    }
+
     pub fn config_path<P: AsRef<Path>>(&self, elm_home: P, elm_version: &str) -> PathBuf {
         Self::packages_dir(elm_home, elm_version)
             .join(&self.author)

--- a/src/project_config.rs
+++ b/src/project_config.rs
@@ -3,7 +3,7 @@
 use crate::constraint::Constraint;
 use pubgrub::range::Range;
 use pubgrub::version::SemanticVersion as SemVer;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::collections::BTreeMap as Map;
 use std::fmt;
 use std::path::{Path, PathBuf};
@@ -50,7 +50,7 @@ pub struct PackageConfig {
     pub test_dependencies: Map<Pkg, Constraint>,
 }
 
-#[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub struct Pkg {
     pub author: String,
     pub pkg: String,
@@ -127,5 +127,22 @@ impl FromStr for Pkg {
 impl fmt::Display for Pkg {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}/{}", &self.author, &self.pkg)
+    }
+}
+
+// Custom serialization for Pkg
+impl Serialize for Pkg {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for Pkg {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        s.parse().map_err(serde::de::Error::custom)
     }
 }

--- a/src/project_config.rs
+++ b/src/project_config.rs
@@ -40,7 +40,7 @@ pub struct AppDependencies {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct PackageConfig {
-    pub name: String,
+    pub name: Pkg,
     pub summary: String,
     pub license: String,
     pub version: SemVer,


### PR DESCRIPTION
This changes the ordering of packages since `elm`/`...` is now earlier than `elm-...`/`...` whereas with strings, we have `"elm-.../..."` earlier than `"elm/..."`